### PR TITLE
switch AWS::CLI::Config::Profile to Class::Tiny, for easier subclassing

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl extension AWS-CLI-Config
 
 {{$NEXT}}
 
+    - convert from Object::Tiny to Class::Tiny in AWS::CLI::Config::Profile,
+      for easier subclassing.
+
 0.04 2017-05-20T06:41:39Z
 
     - [Trivial] Drop Config::Tiny from dependencies

--- a/META.json
+++ b/META.json
@@ -42,7 +42,7 @@
       },
       "runtime" : {
          "requires" : {
-            "Object::Tiny" : "0",
+            "Class::Tiny" : "0",
             "perl" : "5.008001"
          }
       },

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'Object::Tiny';
+requires 'Class::Tiny';
 requires 'perl', '5.008001';
 
 on configure => sub {

--- a/lib/AWS/CLI/Config.pm
+++ b/lib/AWS/CLI/Config.pm
@@ -160,7 +160,7 @@ PROFILE: {
         );
     }
 
-    use Object::Tiny @ACCESSORS;
+    use Class::Tiny @ACCESSORS;
 
     sub _new {
         my $class = shift;


### PR DESCRIPTION
Class::Tiny supports BUILD, BUILDARGS etc, so it's possible to subclass
with a Moo or Moose class.